### PR TITLE
Updated create function to accept more params

### DIFF
--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -699,7 +699,16 @@ local ShifterBox = ZO_Object:Subclass()
 -- @param leftListTitle - the title for the left listBox (can be empty)
 -- @param rightListTitle - the title for the right listBox (can be empty)
 -- @param customSettings - custom settings table (can be empty, default settings will be used then)
-function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, leftListTitle, rightListTitle, customSettings)
+-- @param anchorPoint - anchor point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorRelativeTo - anchor relative to control (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorRelPoint - anchor relative point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorOffsetX - anchor offset x (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorOffsetY - anchor offset y (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param dimensionX - dimension x (can be empty, you need to call yourShifterBox:SetDimension on your own then)
+-- @param dimensionY - dimension y (can be empty, you need to call yourShifterBox:SetDimension on your own then)
+-- @param leftListEntries - the left list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToLeftList on your own then)
+-- @param rightListEntries - the right list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToRightList on your own then)
+function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, leftListTitle, rightListTitle, customSettings, anchorPoint, anchorRelativeTo, anchorRelPoint, anchorOffsetX, anchorOffsetY, dimensionX, dimensionY, leftListEntries, rightListEntries)
     if existingShifterBoxes[uniqueAddonName] == nil then
         existingShifterBoxes[uniqueAddonName] = {}
     end
@@ -711,15 +720,50 @@ function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, le
     obj.shifterBoxName = uniqueShifterBoxName
     obj.shifterBoxSettings = _applyCustomSettings(customSettings)
     obj.shifterBoxControl = _createShifterBox(uniqueAddonName, uniqueShifterBoxName, parentControl)
+    local obj_ctrl = obj.shifterBoxControl
     _initShifterBoxControls(obj, leftListTitle, rightListTitle)
     _initShifterBoxHandlers(obj)
 
     -- initialize the ShifterBoxLists
-    local leftControl = obj.shifterBoxControl:GetNamedChild("Left")
-    local rightControl = obj.shifterBoxControl:GetNamedChild("Right")
+    local leftControl = obj_ctrl:GetNamedChild("Left")
+    local rightControl = obj_ctrl:GetNamedChild("Right")
     obj.leftList = ShifterBoxList:New(leftControl, obj.shifterBoxSettings)
     obj.rightList = ShifterBoxList:New(rightControl, obj.shifterBoxSettings)
 
+    --anchor
+    if anchorPoint and anchorRelativeTo then
+        anchorOffsetX = anchorOffsetX or 0
+        anchorOffsetY = anchorOffsetY or 0
+        obj:SetAnchor(anchorPoint, anchorRelativeTo, anchorRelPoint, anchorOffsetX, anchorOffsetY)
+    end
+    --dimensions
+    if dimensionX and dimensionY then
+        obj:SetDimensions(dimensionX, dimensionY)
+    end
+    --list entries left
+    local leftListEntriesTab
+    if leftListEntries then
+        if type(leftListEntries) == "function" then
+            leftListEntriesTab = leftListEntries()
+        else
+            leftListEntriesTab = leftListEntries
+        end
+    end
+    if leftListEntriesTab then
+        obj:AddEntriesToLeftList(leftListEntriesTab)
+    end
+    --list entries right
+    local rightListEntriesTab
+    if rightListEntries then
+        if type(rightListEntries) == "function" then
+            rightListEntriesTab = rightListEntries()
+        else
+            rightListEntriesTab = rightListEntries
+        end
+    end
+    if rightListEntriesTab then
+        obj:AddEntriesToRightList(rightListEntriesTab)
+    end
     -- register the shifterBox in the internal list and return it
     addonShifterBoxes[uniqueShifterBoxName] = obj
     return addonShifterBoxes[uniqueShifterBoxName]

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -20,6 +20,7 @@ local ANIMATION_FIELD_NAME = "SelectionAnimation"
 local existingShifterBoxes = {}
 
 local defaultSettings = {
+    sortEnabled = true,
     sortBy = "value",
     rowHeight = 32,
     emptyListText = "empty",
@@ -85,21 +86,28 @@ end
 function ShifterBoxList:Initialize(control, shifterBoxSettings)
     self.rowHeight = shifterBoxSettings.rowHeight
     self.rowWidth = 180 -- default value to init
+    self.shifterBoxSettings = shifterBoxSettings
     -- initialize the SortFilterList
     ZO_SortFilterList.Initialize(self, control)
     -- set a text that is displayed when there are no entries
     self:SetEmptyText(shifterBoxSettings.emptyListText)
     -- default sorting key
     -- Source: https://esodata.uesp.net/100028/src/libraries/zo_sortheadergroup/zo_sortheadergroup.lua.html
-    self.sortHeaderGroup:SelectHeaderByKey("value")
-    ZO_SortHeader_OnMouseExit(self.control:GetNamedChild("Headers"):GetNamedChild("Value"))
+    if shifterBoxSettings.sortEnabled then
+        self.sortHeaderGroup:SelectHeaderByKey("value")
+        ZO_SortHeader_OnMouseExit(self.control:GetNamedChild("Headers"):GetNamedChild("Value"))
+    else
+        --Disable sort header group
+        self.sortHeaderGroup.origDisabledColor = self.sortHeaderGroup.disabledColor
+        self.sortHeaderGroup.disabledColor = self.sortHeaderGroup.normalColor
+        self.sortHeaderGroup:SetEnabled(false)
+    end
     -- define the datatype for this list and enable the highlighting
     ZO_ScrollList_AddCategory(self.list, DATA_DEFAULT_CATEGORY)
     ZO_ScrollList_AddDataType(self.list, DATA_TYPE_DEFAULT, "ShifterBoxEntryTemplate", self.rowHeight, function(control, data) self:SetupRowEntry(control, data) end)
     ZO_ScrollList_EnableSelection(self.list, "ZO_ThinListHighlight", function(...)
         self:OnSelectionChanged(...)
     end)
-
     -- set up sorting function and refresh all data
     self.sortFunction = function(listEntry1, listEntry2) return ZO_TableOrderingFunction(listEntry1.data, listEntry2.data, shifterBoxSettings.sortBy, ShifterBoxList.SORT_KEYS, self.currentSortOrder) end
     self:RefreshData()
@@ -156,10 +164,13 @@ function ShifterBoxList:FilterScrollList()
 end
 
 function ShifterBoxList:SortScrollList()
-    -- intended to be overriden
-    -- should take the filtered data and sort it
-    local scrollData = ZO_ScrollList_GetDataList(self.list)
-    table.sort(scrollData, self.sortFunction)
+    local shifterBoxSettings = self.shifterBoxSettings
+    if shifterBoxSettings.sortEnabled then
+        -- intended to be overriden
+        -- should take the filtered data and sort it
+        local scrollData = ZO_ScrollList_GetDataList(self.list)
+        table.sort(scrollData, self.sortFunction)
+    end
 end
 
 function ShifterBoxList:AddEntry(key, value, categoryId)
@@ -508,9 +519,12 @@ local function _applyCustomSettings(customSettings)
     local settings = ZO_ShallowTableCopy(defaultSettings)
     if customSettings == nil then return settings end
     -- otherwise validate them
-    if customSettings.sortBy then
-        assert(customSettings.sortBy == "value" or customSettings.sortBy == "key", string.format(LIB_IDENTIFIER.."_Error: Invalid sortBy parameter '%s' provided! Only 'value' and 'key' are allowed.", tostring(customSettings.sortBy)))
-        settings.sortBy = customSettings.sortBy
+    if customSettings.sortEnabled ~= nil then
+        settings.sortEnabled = customSettings.sortEnabled
+        if customSettings.sortBy then
+            assert(customSettings.sortBy == "value" or customSettings.sortBy == "key", string.format(LIB_IDENTIFIER.."_Error: Invalid sortBy parameter '%s' provided! Only 'value' and 'key' are allowed.", tostring(customSettings.sortBy)))
+            settings.sortBy = customSettings.sortBy
+        end
     end
     if customSettings.rowHeight then
         assert(type(customSettings.rowHeight) == "number" and customSettings.rowHeight > 0, string.format(LIB_IDENTIFIER.."_Error: Invalid rowHeight parameter '%s' provided! Must be a numeric and positive.", tostring(customSettings.rowHeight)))


### PR DESCRIPTION
Updated create/LIbShifterBox function to accept more params:
-- @param anchorPoint - anchor point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
-- @param anchorRelativeTo - anchor relative to control (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
-- @param anchorRelPoint - anchor relative point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
-- @param anchorOffsetX - anchor offset x (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
-- @param anchorOffsetY - anchor offset y (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
-- @param dimensionX - dimension x (can be empty, you need to call yourShifterBox:SetDimension on your own then)
-- @param dimensionY - dimension y (can be empty, you need to call yourShifterBox:SetDimension on your own then)
-- @param leftListEntries - the left list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToLeftList on your own then)
-- @param rightListEntries - the right list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToRightList on your own then)
function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, leftListTitle, rightListTitle, customSettings, anchorPoint, anchorRelativeTo, anchorRelPoint, anchorOffsetX, anchorOffsetY, dimensionX, dimensionY, leftListEntries, rightListEntries)