### PR TITLE
Added drag&drop between lists and several other stuff (XML row templates, multi language support, ...)

### DIFF
--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -47,354 +47,6 @@ local function _getShallowClonedTable(sourceTable)
     return targetTable
 end
 
-
--- =================================================================================================================
--- == SCROLL-LISTS == --
--- -----------------------------------------------------------------------------------------------------------------
--- Source: https://esoapi.uesp.net/100028/src/libraries/zo_sortfilterlist/zo_sortfilterlist.lua.html
-local ShifterBoxList = ZO_SortFilterList:Subclass()
-
-ShifterBoxList.SORT_KEYS = {
-    ["value"] = {},
-    ["key"] = {tiebreaker="value"}
-}
-
-function ShifterBoxList:New(control, shifterBoxSettings)
-    local obj = ZO_SortFilterList.New(self, control, shifterBoxSettings)
-    obj.buttonControl = control:GetNamedChild("Button")
-    obj.buttonAllControl = control:GetNamedChild("AllButton")
-    obj.buttonAllControl:SetState(BSTATE_DISABLED, true) -- init it as disabled
-    if shifterBoxSettings.showMoveAllButtons == false then obj.buttonAllControl:SetHidden(true) end
-    obj.enabled = true
-    obj.masterList = {}
-    return obj
-end
-
-function ShifterBoxList:OnSelectionChanged(previouslySelectedData, selectedData, reselectingDuringRebuild)
-    local selectedMultiData = self.list.selectedMultiData
-    if selectedMultiData then
-        local count = 0
-        for _ in pairs(selectedMultiData) do count = count + 1 end
-        if count > 0 then
-            self.buttonControl:SetState(BSTATE_NORMAL, false)
-        else
-            self.buttonControl:SetState(BSTATE_DISABLED, true)
-        end
-    end
-end
-
-function ShifterBoxList:Initialize(control, shifterBoxSettings)
-    self.rowHeight = shifterBoxSettings.rowHeight
-    self.rowWidth = 180 -- default value to init
-    self.shifterBoxSettings = shifterBoxSettings
-    -- initialize the SortFilterList
-    ZO_SortFilterList.Initialize(self, control)
-    -- set a text that is displayed when there are no entries
-    self:SetEmptyText(shifterBoxSettings.emptyListText)
-    if  self.shifterBoxSettings.sortEnabled then
-        -- default sorting key
-        -- Source: https://esodata.uesp.net/100028/src/libraries/zo_sortheadergroup/zo_sortheadergroup.lua.html
-        self.sortHeaderGroup:SelectHeaderByKey("value")
-        ZO_SortHeader_OnMouseExit(self.control:GetNamedChild("Headers"):GetNamedChild("Value"))
-    else
-        -- disable sortHeaderGroup
-        self.sortHeaderGroup.origDisabledColor = self.sortHeaderGroup.disabledColor
-        self.sortHeaderGroup.disabledColor = self.sortHeaderGroup.normalColor
-        self.sortHeaderGroup:SetEnabled(false)
-    end
-    -- define the datatype for this list and enable the highlighting
-    ZO_ScrollList_AddCategory(self.list, DATA_DEFAULT_CATEGORY)
-    ZO_ScrollList_AddDataType(self.list, DATA_TYPE_DEFAULT, "ShifterBoxEntryTemplate", self.rowHeight, function(control, data) self:SetupRowEntry(control, data) end)
-    ZO_ScrollList_EnableSelection(self.list, "ZO_ThinListHighlight", function(...)
-        self:OnSelectionChanged(...)
-    end)
-    -- set up sorting function and refresh all data
-    self.sortFunction = function(listEntry1, listEntry2) return ZO_TableOrderingFunction(listEntry1.data, listEntry2.data, shifterBoxSettings.sortBy, ShifterBoxList.SORT_KEYS, self.currentSortOrder) end
-    self:RefreshData()
-end
-
--- ZO_SortFilterList:RefreshData()      =>  BuildMasterList()   =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()
--- ZO_SortFilterList:RefreshFilters()                           =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()
--- ZO_SortFilterList:RefreshSort()                                                      =>  SortScrollList()    =>  CommitScrollList()
-
-function ShifterBoxList:BuildMasterList()
-    -- intended to be overriden
-    -- should build the master list of data that is later filtered by FilterScrollList
-end
-
-function ShifterBoxList:FilterScrollList()
-    -- intended to be overriden
-    -- should take the master list data and filter it
-    local hasAtLeastOneEntry = false
-    local scrollData = ZO_ScrollList_GetDataList(self.list)
-    ZO_ClearNumericallyIndexedTable(scrollData)
-    if self.masterList then
-        local categories = self.list.categories
-        for key, data in pairs(self.masterList) do
-            -- check if the categoryId is NOT existing; or NOT set to hidden
-            local category = categories[data.categoryId]
-            if category == nil or category.hidden == false then
-                local rowData = {
-                    key = key,
-                    value = data.value
-                }
-                table.insert(scrollData, ZO_ScrollList_CreateDataEntry(DATA_TYPE_DEFAULT, rowData, data.categoryId or DATA_DEFAULT_CATEGORY))
-                hasAtLeastOneEntry = true
-            else
-                -- entry will not (or will no longer) be visible
-                if self.list.selectedMultiData then
-                    self.list.selectedMultiData[key] = nil
-                end
-            end
-        end
-    end
-    if hasAtLeastOneEntry then
-        -- when there is at least one entry, the move-all button can be enabled
-        self.buttonAllControl:SetState(BSTATE_NORMAL, false)
-        self:OnSelectionChanged()
-    else
-        -- if there are no entries ; disable both move buttons
-        if self.buttonControl then
-            self.buttonControl:SetState(BSTATE_DISABLED, true)
-        end
-        if self.buttonAllControl then
-            self.buttonAllControl:SetState(BSTATE_DISABLED, true)
-        end
-    end
-end
-
-function ShifterBoxList:SortScrollList()
-    -- intended to be overriden
-    -- should take the filtered data and sort it
-    local shifterBoxSettings = self.shifterBoxSettings
-    if shifterBoxSettings.sortEnabled then
-        local scrollData = ZO_ScrollList_GetDataList(self.list)
-        table.sort(scrollData, self.sortFunction)
-    end
-end
-
-function ShifterBoxList:AddEntry(key, value, categoryId)
-    local data = {
-        value = value,
-        categoryId = categoryId
-    }
-    self.masterList[key] = data
-end
-
-function ShifterBoxList:RemoveEntry(key)
-    if self.masterList[key] ~= nil then
-        local data = _getShallowClonedTable(self.masterList[key])
-        -- remove the entry from the masterList
-        self.masterList[key] = nil
-        -- and remove it from the selectedList
-        if self.list.selectedMultiData then
-            self.list.selectedMultiData[key] = nil
-        end
-        return key, data.value, data.categoryId
-    end
-    return nil
-end
-
-function ShifterBoxList:ClearMasterList()
-    self.masterList = {}
-    self:RefreshFilters()
-end
-
-function ShifterBoxList:UnselectEntries()
-    self.list.selectedMultiData = {}
-    self:CommitScrollList()
-    self.buttonControl:SetState(BSTATE_DISABLED, true)
-end
-
---- this function only visually selects an entry, it does NOT store it in the selected-list though!
-function ShifterBoxList:SelectControl(control, animateInstantly)
-    local controlTemplate = self.list.selectionTemplate
-    local animationFieldName = ANIMATION_FIELD_NAME
-    -- SelectControl()
-    if controlTemplate then
-        if not control[animationFieldName] then
-            local highlight = CreateControlFromVirtual("$(parent)Scroll", control, controlTemplate, animationFieldName)
-            control[animationFieldName] = ANIMATION_MANAGER:CreateTimelineFromVirtual("ShowOnMouseOverLabelAnimation", highlight)
-        end
-        if animateInstantly then
-            control[animationFieldName]:PlayInstantlyToEnd()
-        else
-            control[animationFieldName]:PlayForward()
-        end
-    end
-end
-
---- this function only visually unselects an entry, it does NOT remove it from the selected-list though!
-function ShifterBoxList:UnselectControl(control, animateInstantly)
-    local animationFieldName = ANIMATION_FIELD_NAME
-    -- UnselectControl()
-    if control[animationFieldName] then
-        if animateInstantly then
-            control[animationFieldName]:PlayInstantlyToStart()
-        else
-            control[animationFieldName]:PlayBackward()
-        end
-    end
-end
-
--- Custom implementation based on: https://esoapi.uesp.net/100028/src/libraries/zo_templates/scrolltemplates.lua.html#1456
---- this function toggles the selection of an entry and also adds/removes it to/from the selected-list
--- @param data - the table with the data of the entry (mandatory)
--- @param control - the control of the entry (optional - can be deferred from data)
--- @param reselectingDuringRebuild - to be defined
--- @param animateInstantly - if the selection animation is instantly or not
--- @param deselectOnReselect - if the entry is already selected, instead of reselecting it will be deselected
-function ShifterBoxList:ToggleEntrySelection(data, control, reselectingDuringRebuild, animateInstantly, deselectOnReselect )
-    if not self.enabled then return end -- if the listBox is not enabled; immediately exit the function
-    if reselectingDuringRebuild == nil then
-        reselectingDuringRebuild = false
-    end
-    if animateInstantly == nil then
-        animateInstantly = false
-    end
-    if deselectOnReselect  == nil then
-        deselectOnReselect  = true
-    end
-    local dataKey
-    if data ~= nil then
-        for i = 1, #self.list.data do
-            local currData = self.list.data[i].data
-            if currData == data then
-                dataKey = currData.key
-                break
-            end
-        end
-        -- this data we tried to select isn't in the scroll list at all, just abort
-        if dataKey == nil then return end
-    end
-    if self.list.selectedMultiData == nil then
-        self.list.selectedMultiData = {}
-    end
-    if data ~= nil then
-        if not control then
-            control = ZO_ScrollList_GetDataControl(self.list, data)
-        end
-        -- check if already selected
-        if self.list.selectedMultiData[dataKey] == nil then
-            -- add selected data
-            self.list.selectedMultiData[dataKey] = data
-            -- and select the control (if applicable)
-            if control then self:SelectControl(control, animateInstantly) end
-        elseif deselectOnReselect then
-            -- remove selected data
-            self.list.selectedMultiData[dataKey] = nil
-            -- and unselect the control (if applicable)
-            if control then self:UnselectControl(control, animateInstantly) end
-        end
-    end
-    if self.list.selectionCallback then
-        self.list.selectionCallback(data, self.list.selectedMultiData, reselectingDuringRebuild)
-    end
-end
-
-function ShifterBoxList:SetupRowEntry(rowControl, rowData)
-    local subSelf = self
-    local function onRowMouseEnter(rowControl)
-        local labelControl = rowControl:GetNamedChild("Label")
-        local textWidth = labelControl:GetTextWidth()
-        local desiredWidth = labelControl:GetDesiredWidth()
-        -- only show tooltip if the text/label was truncated or if the text is wider than the desiredWidth minus the scrollbar width
-        local wasTruncated = rowControl:GetNamedChild("Label"):WasTruncated()
-        if wasTruncated or (textWidth + SCROLLBAR_WIDTH) > desiredWidth then
-            local data = ZO_ScrollList_GetData(rowControl)
-            ZO_Tooltips_ShowTextTooltip(rowControl, TOP, data.value)
-        end
-    end
-    local function onRowMouseExit(rowControl)
-        ZO_Tooltips_HideTextTooltip()
-    end
-    local function onRowClicked(rowControl)
-        local data = ZO_ScrollList_GetData(rowControl)
-        self:ToggleEntrySelection(data, rowControl, RESELECTING_DURING_REBUILD, false)
-    end
-    -- set the value for the row entry
-    local labelControl = rowControl:GetNamedChild("Label")
-    labelControl:SetText(rowData.value)
-    -- the below two handlers only work if "PersonalAssistantBankingRuleListRowTemplate" is set to a <Button> control
-    rowControl:SetHandler("OnMouseEnter", onRowMouseEnter)
-    rowControl:SetHandler("OnMouseExit", onRowMouseExit)
-    -- handle single clicks to mark entry
-    rowControl:SetHandler("OnClicked", onRowClicked)
-
-    -- set the height for the row
-    rowControl:SetHeight(self.rowHeight)
-    -- and also set the width for the row (to ensure tooltips work properly)
-    rowControl:SetWidth(self.rowWidth)
-    labelControl:SetWidth(self.rowWidth)
-
-    -- reselect entries (only visually) if necessary
-    local selectedMultiData = self.list.selectedMultiData
-    if selectedMultiData and selectedMultiData[rowData.key] ~= nil then
-        self:SelectControl(rowControl, false)
-    end
-
-    -- then setup the row
-    ZO_SortFilterList.SetupRow(self, rowControl, rowData)
-end
-
-function ShifterBoxList:SetCustomDimensions(width, height, headerHeight)
-    -- first set width/height of the listbox itself
-    self.rowWidth = width - SCROLLBAR_WIDTH
-    self.list:SetDimensions(width, height)
-    self.headersContainer:SetDimensions(width, headerHeight)
-    -- and of the header (needed to cut down headers that are too long)
-    local headerValueControl = self.headersContainer:GetNamedChild("Value")
-    headerValueControl:SetWidth(width)
-    -- then re-set the anchor for the arrow to reposition itself
-    local headerValueNameControl = headerValueControl:GetNamedChild("Name")
-    local headerArrowControl = self.headersContainer:GetNamedChild("Arrow")
-    local headerTextWidth = headerValueNameControl:GetTextWidth()
-    headerArrowControl:ClearAnchors()
-    if headerTextWidth > width then
-        -- FIXME: does not correctly work when the ShifterBox is made bigger because the TextWidth() is not updated yet
-        headerArrowControl:SetAnchor(LEFT, headerValueNameControl, LEFT, width, 0)
-    else
-        headerArrowControl:SetAnchor(LEFT, headerValueNameControl, LEFT, headerTextWidth, 0)
-    end
-end
-
-function ShifterBoxList:Refresh()
-    -- make sure that all rows have the correct width
-    local rowControls = self.list.contents
-    for childIndex = 1, rowControls:GetNumChildren() do
-        local rowControl = rowControls:GetChild(childIndex)
-        local rowControlLabel = rowControl:GetNamedChild("Label")
-        rowControlLabel:SetWidth(rowControl:GetWidth())
-    end
-    -- then update the scroll list (i.e. update scrollbar)
-    self:CommitScrollList()
-end
-
-function ShifterBoxList:SetEntriesEnabled(enabled)
-    if not enabled then
-        -- unselect all entries
-        self:UnselectEntries()
-    end
-    -- after unselecing all entries, change the actual state of the rowControl-buttons
-    local rowControls = self.list.contents
-    for childIndex = 1, rowControls:GetNumChildren() do
-        local rowControl = rowControls:GetChild(childIndex)
-        rowControl:SetEnabled(enabled)
-    end
-    rowControls:SetAlpha(enabled and 1 or 0.3)
-    local scrollData = ZO_ScrollList_GetDataList(self.list)
-    local numChildren = #scrollData
-    -- enable/disable the "all" button
-    if enabled and numChildren > 0 then
-        self.buttonAllControl:SetState(BSTATE_NORMAL, false)
-    else
-        self.buttonAllControl:SetState(BSTATE_DISABLED, true)
-    end
-    -- finally, store the enabled state
-    self.enabled = enabled
-end
-
-
 -- =================================================================================================================
 -- == SHIFTERBOX PRIVATE FUNCTIONS == --
 -- -----------------------------------------------------------------------------------------------------------------
@@ -404,9 +56,9 @@ local function _createShifterBox(uniqueAddonName, uniqueShifterBoxName, parentCo
 end
 
 local function _moveEntryFromTo(fromList, toList, key)
-    local key, value, categoryId = fromList:RemoveEntry(key)
-    if key ~= nil then
-        toList:AddEntry(key, value, categoryId)
+    local keyNew, value, categoryId = fromList:RemoveEntry(key)
+    if keyNew ~= nil then
+        toList:AddEntry(keyNew, value, categoryId)
     end
 end
 
@@ -520,12 +172,11 @@ local function _applyCustomSettings(customSettings)
     if customSettings == nil then return settings end
     -- otherwise validate them
     if customSettings.sortEnabled ~= nil then
-        assert(type(customSettings.sortEnabled) == "boolean", string.format(LIB_IDENTIFIER.."_Error: Invalid sortEnabled parameter '%s' provided! Must be a boolean.", tostring(customSettings.sortEnabled)))
         settings.sortEnabled = customSettings.sortEnabled
-    end
-    if customSettings.sortBy then
-        assert(customSettings.sortBy == "value" or customSettings.sortBy == "key", string.format(LIB_IDENTIFIER.."_Error: Invalid sortBy parameter '%s' provided! Only 'value' and 'key' are allowed.", tostring(customSettings.sortBy)))
-        settings.sortBy = customSettings.sortBy
+        if customSettings.sortBy then
+            assert(customSettings.sortBy == "value" or customSettings.sortBy == "key", string.format(LIB_IDENTIFIER.."_Error: Invalid sortBy parameter '%s' provided! Only 'value' and 'key' are allowed.", tostring(customSettings.sortBy)))
+            settings.sortBy = customSettings.sortBy
+        end
     end
     if customSettings.rowHeight then
         assert(type(customSettings.rowHeight) == "number" and customSettings.rowHeight > 0, string.format(LIB_IDENTIFIER.."_Error: Invalid rowHeight parameter '%s' provided! Must be a numeric and positive.", tostring(customSettings.rowHeight)))
@@ -654,34 +305,26 @@ local function _addEntriesToList(list, entries, replace, otherList, categoryId)
         ZO_ScrollList_AddCategory(list.list, categoryId)
         ZO_ScrollList_AddCategory(otherList.list, categoryId)
     end
-    local entriesList
-    if type(entries) == "function" then
-        entriesList = entries()
-    else
-        entriesList = entries
-    end
-    if entriesList then
-        for key, value in pairs(entriesList) do
-            if replace and replace == true then
-                -- if replace is set to true, make sure that a potential entry with the same key is removed from both lists
-                local removeKey = list:RemoveEntry(key)
-                local otherRemoveKey = otherList:RemoveEntry(key)
-                if removeKey ~= nil or otherRemoveKey ~= nil then hasAtLeastOneRemoved = true end
-            else
-                -- if replace is not set or set to false, then assert that key does not exist in either list
-                _assertKeyIsNotInTable(key, value, list, listControl)
-                _assertKeyIsNotInTable(key, value, otherList, otherListControl)
-            end
-            -- then add entry to the corresponding list
-            list:AddEntry(key, value, categoryId)
-            hasAtLeastOneAdded = true
+    for key, value in pairs(entries) do
+        if replace and replace == true then
+            -- if replace is set to true, make sure that a potential entry with the same key is removed from both lists
+            local removeKey = list:RemoveEntry(key)
+            local otherRemoveKey = otherList:RemoveEntry(key)
+            if removeKey ~= nil or otherRemoveKey ~= nil then hasAtLeastOneRemoved = true end
+        else
+            -- if replace is not set or set to false, then assert that key does not exist in either list
+            _assertKeyIsNotInTable(key, value, list, listControl)
+            _assertKeyIsNotInTable(key, value, otherList, otherListControl)
         end
-        if hasAtLeastOneAdded then
-            -- Afterwards refresh the visualisation of the data
-            _refreshFilters(list)
-            if hasAtLeastOneRemoved then
-                _refreshFilters(otherList)
-            end
+        -- then add entry to the corresponding list
+        list:AddEntry(key, value, categoryId)
+        hasAtLeastOneAdded = true
+    end
+    if hasAtLeastOneAdded then
+        -- Afterwards refresh the visualisation of the data
+        _refreshFilters(list)
+        if hasAtLeastOneRemoved then
+            _refreshFilters(otherList)
         end
     end
 end
@@ -709,6 +352,429 @@ local function _clearList(list)
     list.buttonControl:SetState(BSTATE_DISABLED, true)
 end
 
+local function _getTableSize(t)
+    local count = 0
+    for _, __ in pairs(t) do
+        count = count + 1
+    end
+    return count
+end
+
+-- =================================================================================================================
+-- == SCROLL-LISTS == --
+-- -----------------------------------------------------------------------------------------------------------------
+-- Source: https://esoapi.uesp.net/100028/src/libraries/zo_sortfilterlist/zo_sortfilterlist.lua.html
+local ShifterBoxList = ZO_SortFilterList:Subclass()
+
+ShifterBoxList.SORT_KEYS = {
+    ["value"] = {},
+    ["key"] = {tiebreaker="value"}
+}
+
+function ShifterBoxList:New(control, shifterBoxObj, isLeftList)
+    local shifterBoxSettings = shifterBoxObj.shifterBoxSettings
+    local obj = ZO_SortFilterList.New(self, control, shifterBoxObj, isLeftList)
+    obj.buttonControl = control:GetNamedChild("Button")
+    obj.buttonAllControl = control:GetNamedChild("AllButton")
+    obj.buttonAllControl:SetState(BSTATE_DISABLED, true) -- init it as disabled
+    if shifterBoxSettings.showMoveAllButtons == false then obj.buttonAllControl:SetHidden(true) end
+    obj.enabled = true
+    obj.masterList = {}
+    obj.isLeftList = isLeftList
+    obj.shifterBox = shifterBoxObj
+    return obj
+end
+
+function ShifterBoxList:OnSelectionChanged(previouslySelectedData, selectedData, reselectingDuringRebuild)
+    local selectedMultiData = self.list.selectedMultiData
+    if selectedMultiData then
+        local count = 0
+        for _ in pairs(selectedMultiData) do count = count + 1 end
+        if count > 0 then
+            self.buttonControl:SetState(BSTATE_NORMAL, false)
+        else
+            self.buttonControl:SetState(BSTATE_DISABLED, true)
+        end
+    end
+end
+
+function ShifterBoxList:Initialize(control, shifterBoxObj, isLeftList)
+    local shifterBoxSettings = shifterBoxObj.shifterBoxSettings
+    self.rowHeight = shifterBoxSettings.rowHeight
+    self.rowWidth = 180 -- default value to init
+    self.shifterBoxSettings = shifterBoxSettings
+    self.isLeftList = isLeftList
+    self.shifterBox = shifterBoxObj
+    -- initialize the SortFilterList
+    ZO_SortFilterList.Initialize(self, control)
+    -- set a text that is displayed when there are no entries
+    self:SetEmptyText(shifterBoxSettings.emptyListText)
+    -- default sorting key
+    -- Source: https://esodata.uesp.net/100028/src/libraries/zo_sortheadergroup/zo_sortheadergroup.lua.html
+    if shifterBoxSettings.sortEnabled then
+        self.sortHeaderGroup:SelectHeaderByKey("value")
+        ZO_SortHeader_OnMouseExit(self.control:GetNamedChild("Headers"):GetNamedChild("Value"))
+    else
+        --Disable sort header group
+        self.sortHeaderGroup.origDisabledColor = self.sortHeaderGroup.disabledColor
+        self.sortHeaderGroup.disabledColor = self.sortHeaderGroup.normalColor
+        self.sortHeaderGroup:SetEnabled(false)
+    end
+    -- define the datatype for this list and enable the highlighting
+    ZO_ScrollList_AddCategory(self.list, DATA_DEFAULT_CATEGORY)
+    ZO_ScrollList_AddDataType(self.list, DATA_TYPE_DEFAULT, "ShifterBoxEntryTemplate", self.rowHeight, function(control, data) self:SetupRowEntry(control, data) end)
+    ZO_ScrollList_EnableSelection(self.list, "ZO_ThinListHighlight", function(...)
+        self:OnSelectionChanged(...)
+    end)
+    -- set up sorting function and refresh all data
+    self.sortFunction = function(listEntry1, listEntry2) return ZO_TableOrderingFunction(listEntry1.data, listEntry2.data, shifterBoxSettings.sortBy, ShifterBoxList.SORT_KEYS, self.currentSortOrder) end
+    self:RefreshData()
+    --Drag reeceive handler
+    local function onDragEnd(draggedOntoControl, mouseButton)
+        WINDOW_MANAGER:SetMouseCursor(MOUSE_CURSOR_DEFAULT_CURSOR)
+        if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
+            --Only if we do not drag any item or skill
+            if GetCursorContentType() == MOUSE_CONTENT_EMPTY then
+                local dragData = lib.currentDragData
+                if dragData then
+                    local sourceListControl = dragData._dragStartList
+G_LSB = {}
+G_LSB.sourceListControl = sourceListControl
+G_LSB.draggedControl = dragData._draggedControl
+
+                    if sourceListControl and sourceListControl ~= draggedOntoControl then
+                        local sourceListSelectedData, srcList, destList
+                        sourceListSelectedData = sourceListControl.selectedMultiData
+                        --No items were marked? Then only 1 item get's dragged directly
+                        if not sourceListSelectedData or (sourceListSelectedData and _getTableSize(sourceListSelectedData)==0) then
+                            if dragData.key then
+                                sourceListSelectedData = sourceListSelectedData or {}
+                                sourceListSelectedData[dragData.key] = dragData
+                                sourceListControl.selectedMultiData = sourceListSelectedData
+                            end
+                        end
+G_LSB.sourceListSelectedData = sourceListSelectedData
+                        destList = self
+                        if self.isLeftList then
+                            srcList = self.shifterBox.rightList
+                        else
+                            srcList = self.shifterBox.leftList
+                        end
+                        if srcList and destList and sourceListSelectedData then
+                            for key, data in pairs(sourceListSelectedData) do
+                                --Remove (set nil) the dragged data information in the rowControl dragged
+                                data._dragStartList = nil
+                                --Move the entry to the other list
+                                _moveEntryFromTo(srcList, destList, key)
+                            end
+                            -- then commit the changes to the scrollList and refresh the hidden states
+                            _refreshFilters(srcList, destList)
+                        end
+                    end
+                    --Clear lib'S current dragged data table again
+                    lib.currentDragData = nil
+                end
+            end
+        end
+    end
+    -- handle drop (drag receive)
+    self.list:SetHandler("OnReceiveDrag", onDragEnd)
+    self.list:SetMouseEnabled(true)
+end
+
+-- ZO_SortFilterList:RefreshData()      =>  BuildMasterList()   =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()
+-- ZO_SortFilterList:RefreshFilters()                           =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()
+-- ZO_SortFilterList:RefreshSort()                                                      =>  SortScrollList()    =>  CommitScrollList()
+
+function ShifterBoxList:BuildMasterList()
+    -- intended to be overriden
+    -- should build the master list of data that is later filtered by FilterScrollList
+end
+
+function ShifterBoxList:FilterScrollList()
+    -- intended to be overriden
+    -- should take the master list data and filter it
+    local hasAtLeastOneEntry = false
+    local scrollData = ZO_ScrollList_GetDataList(self.list)
+    ZO_ClearNumericallyIndexedTable(scrollData)
+    if self.masterList then
+        local categories = self.list.categories
+        for key, data in pairs(self.masterList) do
+            -- check if the categoryId is NOT existing; or NOT set to hidden
+            local category = categories[data.categoryId]
+            if category == nil or category.hidden == false then
+                local rowData = {
+                    key = key,
+                    value = data.value
+                }
+                table.insert(scrollData, ZO_ScrollList_CreateDataEntry(DATA_TYPE_DEFAULT, rowData, data.categoryId or DATA_DEFAULT_CATEGORY))
+                hasAtLeastOneEntry = true
+            else
+                -- entry will not (or will no longer) be visible
+                if self.list.selectedMultiData then
+                    self.list.selectedMultiData[key] = nil
+                end
+            end
+        end
+    end
+    if hasAtLeastOneEntry then
+        -- when there is at least one entry, the move-all button can be enabled
+        self.buttonAllControl:SetState(BSTATE_NORMAL, false)
+        self:OnSelectionChanged()
+    else
+        -- if there are no entries ; disable both move buttons
+        if self.buttonControl then
+            self.buttonControl:SetState(BSTATE_DISABLED, true)
+        end
+        if self.buttonAllControl then
+            self.buttonAllControl:SetState(BSTATE_DISABLED, true)
+        end
+    end
+end
+
+function ShifterBoxList:SortScrollList()
+    local shifterBoxSettings = self.shifterBoxSettings
+    if shifterBoxSettings.sortEnabled then
+        -- intended to be overriden
+        -- should take the filtered data and sort it
+        local scrollData = ZO_ScrollList_GetDataList(self.list)
+        table.sort(scrollData, self.sortFunction)
+    end
+end
+
+function ShifterBoxList:AddEntry(key, value, categoryId)
+    local data = {
+        value = value,
+        categoryId = categoryId
+    }
+    self.masterList[key] = data
+end
+
+function ShifterBoxList:RemoveEntry(key)
+    if self.masterList[key] ~= nil then
+        local data = _getShallowClonedTable(self.masterList[key])
+        -- remove the entry from the masterList
+        self.masterList[key] = nil
+        -- and remove it from the selectedList
+        if self.list.selectedMultiData then
+            self.list.selectedMultiData[key] = nil
+        end
+        return key, data.value, data.categoryId
+    end
+    return nil
+end
+
+function ShifterBoxList:ClearMasterList()
+    self.masterList = {}
+    self:RefreshFilters()
+end
+
+function ShifterBoxList:UnselectEntries()
+    self.list.selectedMultiData = {}
+    self:CommitScrollList()
+    self.buttonControl:SetState(BSTATE_DISABLED, true)
+end
+
+--- this function only visually selects an entry, it does NOT store it in the selected-list though!
+function ShifterBoxList:SelectControl(control, animateInstantly)
+    local controlTemplate = self.list.selectionTemplate
+    local animationFieldName = ANIMATION_FIELD_NAME
+    -- SelectControl()
+    if controlTemplate then
+        if not control[animationFieldName] then
+            local highlight = CreateControlFromVirtual("$(parent)Scroll", control, controlTemplate, animationFieldName)
+            control[animationFieldName] = ANIMATION_MANAGER:CreateTimelineFromVirtual("ShowOnMouseOverLabelAnimation", highlight)
+        end
+        if animateInstantly then
+            control[animationFieldName]:PlayInstantlyToEnd()
+        else
+            control[animationFieldName]:PlayForward()
+        end
+    end
+end
+
+--- this function only visually unselects an entry, it does NOT remove it from the selected-list though!
+function ShifterBoxList:UnselectControl(control, animateInstantly)
+    local animationFieldName = ANIMATION_FIELD_NAME
+    -- UnselectControl()
+    if control[animationFieldName] then
+        if animateInstantly then
+            control[animationFieldName]:PlayInstantlyToStart()
+        else
+            control[animationFieldName]:PlayBackward()
+        end
+    end
+end
+
+-- Custom implementation based on: https://esoapi.uesp.net/100028/src/libraries/zo_templates/scrolltemplates.lua.html#1456
+--- this function toggles the selection of an entry and also adds/removes it to/from the selected-list
+-- @param data - the table with the data of the entry (mandatory)
+-- @param control - the control of the entry (optional - can be deferred from data)
+-- @param reselectingDuringRebuild - to be defined
+-- @param animateInstantly - if the selection animation is instantly or not
+-- @param deselectOnReselect - if the entry is already selected, instead of reselecting it will be deselected
+function ShifterBoxList:ToggleEntrySelection(data, control, reselectingDuringRebuild, animateInstantly, deselectOnReselect )
+    if not self.enabled then return end -- if the listBox is not enabled; immediately exit the function
+    if reselectingDuringRebuild == nil then
+        reselectingDuringRebuild = false
+    end
+    if animateInstantly == nil then
+        animateInstantly = false
+    end
+    if deselectOnReselect  == nil then
+        deselectOnReselect  = true
+    end
+    local dataKey
+    if data ~= nil then
+        for i = 1, #self.list.data do
+            local currData = self.list.data[i].data
+            if currData == data then
+                dataKey = currData.key
+                break
+            end
+        end
+        -- this data we tried to select isn't in the scroll list at all, just abort
+        if dataKey == nil then return end
+    end
+    if self.list.selectedMultiData == nil then
+        self.list.selectedMultiData = {}
+    end
+    if data ~= nil then
+        if not control then
+            control = ZO_ScrollList_GetDataControl(self.list, data)
+        end
+        -- check if already selected
+        if self.list.selectedMultiData[dataKey] == nil then
+            -- add selected data
+            self.list.selectedMultiData[dataKey] = data
+            -- and select the control (if applicable)
+            if control then self:SelectControl(control, animateInstantly) end
+        elseif deselectOnReselect then
+            -- remove selected data
+            self.list.selectedMultiData[dataKey] = nil
+            -- and unselect the control (if applicable)
+            if control then self:UnselectControl(control, animateInstantly) end
+        end
+    end
+    if self.list.selectionCallback then
+        self.list.selectionCallback(data, self.list.selectedMultiData, reselectingDuringRebuild)
+    end
+end
+
+function ShifterBoxList:SetupRowEntry(rowControl, rowData)
+    local function onRowMouseEnter(rowControl)
+        local labelControl = rowControl:GetNamedChild("Label")
+        local textWidth = labelControl:GetTextWidth()
+        local desiredWidth = labelControl:GetDesiredWidth()
+        -- only show tooltip if the text/label was truncated or if the text is wider than the desiredWidth minus the scrollbar width
+        local wasTruncated = rowControl:GetNamedChild("Label"):WasTruncated()
+        if wasTruncated or (textWidth + SCROLLBAR_WIDTH) > desiredWidth then
+            local data = ZO_ScrollList_GetData(rowControl)
+            ZO_Tooltips_ShowTextTooltip(rowControl, TOP, data.value)
+        end
+    end
+    local function onRowMouseExit(rowControl)
+        ZO_Tooltips_HideTextTooltip()
+    end
+    local function onRowClicked(rowControl)
+        local data = ZO_ScrollList_GetData(rowControl)
+        self:ToggleEntrySelection(data, rowControl, RESELECTING_DURING_REBUILD, false)
+    end
+    local function onDragStart(rowControl, mouseButton)
+        lib.currentDragData = nil
+        if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
+            WINDOW_MANAGER:SetMouseCursor(MOUSE_CURSOR_UI_HAND)
+            local dragData = ZO_ScrollList_GetData(rowControl)
+            dragData._dragStartList = rowControl:GetParent():GetParent()
+            lib.currentDragData = dragData
+        else
+            WINDOW_MANAGER:SetMouseCursor(MOUSE_CURSOR_DEFAULT_CURSOR)
+        end
+
+    end
+    -- set the value for the row entry
+    local labelControl = rowControl:GetNamedChild("Label")
+    labelControl:SetText(rowData.value)
+    -- the below two handlers only work if "PersonalAssistantBankingRuleListRowTemplate" is set to a <Button> control
+    rowControl:SetHandler("OnMouseEnter", onRowMouseEnter)
+    rowControl:SetHandler("OnMouseExit", onRowMouseExit)
+    -- handle single clicks to mark entry
+    rowControl:SetHandler("OnClicked", onRowClicked)
+    -- handle drag (drag start)
+    rowControl:SetHandler("OnDragStart", onDragStart)
+
+    -- set the height for the row
+    rowControl:SetHeight(self.rowHeight)
+    -- and also set the width for the row (to ensure tooltips work properly)
+    rowControl:SetWidth(self.rowWidth)
+    labelControl:SetWidth(self.rowWidth)
+
+    -- reselect entries (only visually) if necessary
+    local selectedMultiData = self.list.selectedMultiData
+    if selectedMultiData and selectedMultiData[rowData.key] ~= nil then
+        self:SelectControl(rowControl, false)
+    end
+
+    -- then setup the row
+    ZO_SortFilterList.SetupRow(self, rowControl, rowData)
+end
+
+function ShifterBoxList:SetCustomDimensions(width, height, headerHeight)
+    -- first set width/height of the listbox itself
+    self.rowWidth = width - SCROLLBAR_WIDTH
+    self.list:SetDimensions(width, height)
+    self.headersContainer:SetDimensions(width, headerHeight)
+    -- and of the header (needed to cut down headers that are too long)
+    local headerValueControl = self.headersContainer:GetNamedChild("Value")
+    headerValueControl:SetWidth(width)
+    -- then re-set the anchor for the arrow to reposition itself
+    local headerValueNameControl = headerValueControl:GetNamedChild("Name")
+    local headerArrowControl = self.headersContainer:GetNamedChild("Arrow")
+    local headerTextWidth = headerValueNameControl:GetTextWidth()
+    headerArrowControl:ClearAnchors()
+    if headerTextWidth > width then
+        -- FIXME: does not correctly work when the ShifterBox is made bigger because the TextWidth() is not updated yet
+        headerArrowControl:SetAnchor(LEFT, headerValueNameControl, LEFT, width, 0)
+    else
+        headerArrowControl:SetAnchor(LEFT, headerValueNameControl, LEFT, headerTextWidth, 0)
+    end
+end
+
+function ShifterBoxList:Refresh()
+    -- make sure that all rows have the correct width
+    local rowControls = self.list.contents
+    for childIndex = 1, rowControls:GetNumChildren() do
+        local rowControl = rowControls:GetChild(childIndex)
+        local rowControlLabel = rowControl:GetNamedChild("Label")
+        rowControlLabel:SetWidth(rowControl:GetWidth())
+    end
+    -- then update the scroll list (i.e. update scrollbar)
+    self:CommitScrollList()
+end
+
+function ShifterBoxList:SetEntriesEnabled(enabled)
+    if not enabled then
+        -- unselect all entries
+        self:UnselectEntries()
+    end
+    -- after unselecing all entries, change the actual state of the rowControl-buttons
+    local rowControls = self.list.contents
+    for childIndex = 1, rowControls:GetNumChildren() do
+        local rowControl = rowControls:GetChild(childIndex)
+        rowControl:SetEnabled(enabled)
+    end
+    rowControls:SetAlpha(enabled and 1 or 0.3)
+    local scrollData = ZO_ScrollList_GetDataList(self.list)
+    local numChildren = #scrollData
+    -- enable/disable the "all" button
+    if enabled and numChildren > 0 then
+        self.buttonAllControl:SetState(BSTATE_NORMAL, false)
+    else
+        self.buttonAllControl:SetState(BSTATE_DISABLED, true)
+    end
+    -- finally, store the enabled state
+    self.enabled = enabled
+end
 
 -- =================================================================================================================
 -- == SHIFTERBOX PUBLIC FUNCTIONS == --
@@ -719,14 +785,19 @@ local ShifterBox = ZO_Object:Subclass()
 -- @param uniqueAddonName - the unique name of your addon
 -- @param uniqueShifterBoxName - the unique name of this shifterBox (within your addon)
 -- @param parentControl - the control reference to which the shifterBox should be added as a child
--- @param leftListTitle - OPTIONAL: the title for the left listBox
--- @param rightListTitle - OPTIONAL: the title for the right listBox
--- @param customSettings - OPTIONAL: custom settings table (if empty, default settings will be used)
--- @param anchorOptions - OPTIONAL: directly provide anchorOptions instead of calling :SetAnchor afterwards (must be table with: number whereOnMe, object anchorTargetControl, number whereOnTarget, number offsetX, number offsetY)
--- @param dimensionOptions - OPTIONAL: directly provide dimensionOptions instead of calling :SetDimensions afterwards (must be table with: number width, number height)
--- @param leftListEntries - OPTIONAL: directly provide entries for left listBox (a table or a function returning a table)
--- @param rightListEntries - OPTIONAL: directly provide entries for right listBox (a table or a function returning a table)
-function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, leftListTitle, rightListTitle, customSettings, anchorOptions, dimensionOptions, leftListEntries, rightListEntries)
+-- @param leftListTitle - the title for the left listBox (can be empty)
+-- @param rightListTitle - the title for the right listBox (can be empty)
+-- @param customSettings - custom settings table (can be empty, default settings will be used then)
+-- @param anchorPoint - anchor point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorRelativeTo - anchor relative to control (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorRelPoint - anchor relative point (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorOffsetX - anchor offset x (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param anchorOffsetY - anchor offset y (can be empty, you need to call yourShifterBox:SetAnchor on your own then)
+-- @param dimensionX - dimension x (can be empty, you need to call yourShifterBox:SetDimension on your own then)
+-- @param dimensionY - dimension y (can be empty, you need to call yourShifterBox:SetDimension on your own then)
+-- @param leftListEntries - the left list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToLeftList on your own then)
+-- @param rightListEntries - the right list's entry. A table or a function returning a table (can be left entry. You need to add the entries via yourShifterBox:AddEntriesToRightList on your own then)
+function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, leftListTitle, rightListTitle, customSettings, anchorPoint, anchorRelativeTo, anchorRelPoint, anchorOffsetX, anchorOffsetY, dimensionX, dimensionY, leftListEntries, rightListEntries)
     if existingShifterBoxes[uniqueAddonName] == nil then
         existingShifterBoxes[uniqueAddonName] = {}
     end
@@ -738,28 +809,49 @@ function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, le
     obj.shifterBoxName = uniqueShifterBoxName
     obj.shifterBoxSettings = _applyCustomSettings(customSettings)
     obj.shifterBoxControl = _createShifterBox(uniqueAddonName, uniqueShifterBoxName, parentControl)
+    local obj_ctrl = obj.shifterBoxControl
     _initShifterBoxControls(obj, leftListTitle, rightListTitle)
     _initShifterBoxHandlers(obj)
+
     -- initialize the ShifterBoxLists
-    local leftControl = obj.shifterBoxControl:GetNamedChild("Left")
-    local rightControl = obj.shifterBoxControl:GetNamedChild("Right")
-    obj.leftList = ShifterBoxList:New(leftControl, obj.shifterBoxSettings)
-    obj.rightList = ShifterBoxList:New(rightControl, obj.shifterBoxSettings)
-    -- anchorOptions; if provided
-    if anchorOptions then
-        obj:SetAnchor(unpack(anchorOptions))
+    local leftControl = obj_ctrl:GetNamedChild("Left")
+    local rightControl = obj_ctrl:GetNamedChild("Right")
+    obj.leftList = ShifterBoxList:New(leftControl, obj, true)
+    obj.rightList = ShifterBoxList:New(rightControl, obj, false)
+
+    --anchor
+    if anchorPoint and anchorRelativeTo then
+        anchorOffsetX = anchorOffsetX or 0
+        anchorOffsetY = anchorOffsetY or 0
+        obj:SetAnchor(anchorPoint, anchorRelativeTo, anchorRelPoint, anchorOffsetX, anchorOffsetY)
     end
-    -- dimensionOptions; if provided
-    if dimensionOptions then
-        obj:SetDimensions(unpack(dimensionOptions))
+    --dimensions
+    if dimensionX and dimensionY then
+        obj:SetDimensions(dimensionX, dimensionY)
     end
-    -- leftListEntries; if provided
+    --list entries left
+    local leftListEntriesTab
     if leftListEntries then
-        obj:AddEntriesToLeftList(leftListEntries)
+        if type(leftListEntries) == "function" then
+            leftListEntriesTab = leftListEntries()
+        else
+            leftListEntriesTab = leftListEntries
+        end
     end
-    -- rightListEntries; if provided
+    if leftListEntriesTab then
+        obj:AddEntriesToLeftList(leftListEntriesTab)
+    end
+    --list entries right
+    local rightListEntriesTab
     if rightListEntries then
-        obj:AddEntriesToRightList(rightListEntries)
+        if type(rightListEntries) == "function" then
+            rightListEntriesTab = rightListEntries()
+        else
+            rightListEntriesTab = rightListEntries
+        end
+    end
+    if rightListEntriesTab then
+        obj:AddEntriesToRightList(rightListEntriesTab)
     end
     -- register the shifterBox in the internal list and return it
     addonShifterBoxes[uniqueShifterBoxName] = obj
@@ -879,6 +971,10 @@ end
 
 -- ---------------------------------------------------------------------------------------------------------------------
 
+function ShifterBox:GetLeftList()
+    return self.leftList
+end
+
 function ShifterBox:GetLeftListEntries(withCategoryId)
     return _getEntries(self.leftList, false, withCategoryId)
 end
@@ -916,6 +1012,9 @@ function ShifterBox:ClearLeftList()
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------
+function ShifterBox:GetRightList()
+    return self.rightList
+end
 
 function ShifterBox:GetRightListEntries(withCategoryId)
     return _getEntries(self.rightList, false, withCategoryId)

--- a/LibShifterBox/LibShifterBox.txt
+++ b/LibShifterBox/LibShifterBox.txt
@@ -12,6 +12,9 @@
 ## APIVersion: 100028
 ## IsLibrary: true
 
-ShifterBox\ShifterBoxTemplate.xml
+lang/en.lua
+lang/$(language).lua
+
+ShifterBox/ShifterBoxTemplate.xml
 
 LibShifterBox.lua

--- a/LibShifterBox/ShifterBox/ShifterBoxTemplate.xml
+++ b/LibShifterBox/ShifterBox/ShifterBoxTemplate.xml
@@ -1,5 +1,9 @@
 <GuiXml>
+    <Font name="MyFontGame16" font="$(MEDIUM_FONT)|$(KB_16)|soft-shadow-thin" />
+    <Font name="MyFontGame18" font="$(MEDIUM_FONT)|$(KB_18)|soft-shadow-thin" />
+    <Font name="MyFontGame20" font="$(MEDIUM_FONT)|$(KB_20)|soft-shadow-thin" />
     <Controls>
+        <!-- Virtual control for the ShifterBox -->
         <Control name="ShifterBoxTemplate" resizeToFitDescendents="true" virtual="true">
             <Controls>
                 <Control name="$(parent)Left">
@@ -90,14 +94,40 @@
                 </Control>
             </Controls>
         </Control>
-        <Button name="ShifterBoxEntryTemplate" verticalAlignment="CENTER" horizontalAlignment="LEFT" virtual="true">
+        <!-- Virtual labels -->
+        <Label name="ShifterBoxRowLabel16" color="FFFFFF" font="MyFontGame16" wrapMode="ELLIPSIS" horizontalAlignment="LEFT" verticalAlignment="CENTER" virtual="true" > </Label>
+        <Label name="ShifterBoxRowLabel18" color="FFFFFF" font="MyFontGame18" wrapMode="ELLIPSIS" horizontalAlignment="LEFT" verticalAlignment="CENTER" virtual="true" > </Label>
+        <Label name="ShifterBoxRowLabel20" color="FFFFFF" font="MyFontGame20" wrapMode="ELLIPSIS" horizontalAlignment="LEFT" verticalAlignment="CENTER" virtual="true" > </Label>
+        <!-- Virtual controls - Row of the lists -->
+        <Control name="ShifterBoxEntryTemplate16" verticalAlignment="CENTER" horizontalAlignment="LEFT" mouseEnabled="true" virtual="true">
             <Dimensions x="180" y="32" />
             <Controls>
-                <Label name="$(parent)Label" font="ZoFontGame" verticalAlignment="CENTER" horizontalAlignment="LEFT">
+                <!--<Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />-->
+                <Label name="$(parent)Label" inherits="ShifterBoxRowLabel16">
                     <Anchor point="LEFT" offsetX="10"/>
                     <Dimensions x="180" y="32" />
                 </Label>
             </Controls>
-        </Button>
+        </Control>
+        <Control name="ShifterBoxEntryTemplate18" verticalAlignment="CENTER" horizontalAlignment="LEFT" mouseEnabled="true" virtual="true">
+            <Dimensions x="180" y="32" />
+            <Controls>
+                <!--<Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />-->
+                <Label name="$(parent)Label" inherits="ShifterBoxRowLabel18">
+                    <Anchor point="LEFT" offsetX="10"/>
+                    <Dimensions x="180" y="32" />
+                </Label>
+            </Controls>
+        </Control>
+        <Control name="ShifterBoxEntryTemplate20" verticalAlignment="CENTER" horizontalAlignment="LEFT" mouseEnabled="true" virtual="true">
+            <Dimensions x="180" y="32" />
+            <Controls>
+                <!--<Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />-->
+                <Label name="$(parent)Label" inherits="ShifterBoxRowLabel20">
+                    <Anchor point="LEFT" offsetX="10"/>
+                    <Dimensions x="180" y="32" />
+                </Label>
+            </Controls>
+        </Control>
     </Controls>
 </GuiXml>

--- a/LibShifterBox/lang/de.lua
+++ b/LibShifterBox/lang/de.lua
@@ -1,0 +1,7 @@
+local strings = {
+    LIBSHIFTERBOX_EMPTY = "leer"
+}
+for stringId, stringValue in pairs(strings) do
+    ZO_CreateStringId(stringId, stringValue)
+    SafeAddVersion(stringId, 1)
+end

--- a/LibShifterBox/lang/en.lua
+++ b/LibShifterBox/lang/en.lua
@@ -1,0 +1,7 @@
+local strings = {
+    LIBSHIFTERBOX_EMPTY = "empty"
+}
+for stringId, stringValue in pairs(strings) do
+    ZO_CreateStringId(stringId, stringValue)
+    SafeAddVersion(stringId, 1)
+end

--- a/LibShifterBox/lang/fr.lua
+++ b/LibShifterBox/lang/fr.lua
@@ -1,0 +1,6 @@
+local strings = {
+    LIBSHIFTERBOX_EMPTY = "vide"
+}
+for stringId, stringValue in pairs(strings) do
+    SafeAddString(stringId, stringValue, 1)
+end

--- a/LibShifterBox/lang/jp.lua
+++ b/LibShifterBox/lang/jp.lua
@@ -1,0 +1,7 @@
+local strings = {
+    LIBSHIFTERBOX_EMPTY = "空の"
+}
+for stringId, stringValue in pairs(strings) do
+    ZO_CreateStringId(stringId, stringValue)
+    SafeAddVersion(stringId, 1)
+end

--- a/LibShifterBox/lang/ru.lua
+++ b/LibShifterBox/lang/ru.lua
@@ -1,0 +1,7 @@
+local strings = {
+    LIBSHIFTERBOX_EMPTY = "пустой"
+}
+for stringId, stringValue in pairs(strings) do
+    ZO_CreateStringId(stringId, stringValue)
+    SafeAddVersion(stringId, 1)
+end


### PR DESCRIPTION
-new parameters for SHifterBox:New to set the row templates (Defined in XML file) for left and/or right list. Can be left empty. Standard template will be font size 18:
-- @param rowTemplateNameLeft - the left list's row XML template. Standard is "ShifterBoxEntryTemplate16" with normal ZO_Game font in size 18 (See file ShifterBox/ShifterBoxTemplate.xml)
-- @param rowTemplateNameRight - the right list's row XML template. Standard is "ShifterBoxEntryTemplate16" with normal ZO_Game font in size 18 (See file ShifterBox/ShifterBoxTemplate.xml)

-Added drag&drop for list entries

-Added 3 row templates in XML for font sizes 16, 18 (Standard) and 20: ShifterBoxEntryTemplate16, ShifterBoxEntryTemplate18, ShifterBoxEntryTemplate20

-Added multi language support. Currently only used for the "empty" text. Supported so far: de, en, fr, ru, jp

-Changed virtual button control in XML for the row entries to be a normal control (no button) in an attempt to fix the color problems

-Changed OnClick event handler to OnMouseUp event handler to support non-button control