### PR TITLE
fixed an issue with <</>> buttons disabled state when new entries get added with MOVED event

### DIFF
--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -164,8 +164,6 @@ local function _initShifterBoxHandlers(self)
     local function toLeftAllButtonClicked(buttonControl)
         -- move all entries
         self:MoveAllEntriesToLeftList()
-        -- and disable the move-all button
-        buttonControl:SetState(BSTATE_DISABLED, true)
     end
 
     local function toRightButtonClicked(buttonControl)
@@ -182,8 +180,6 @@ local function _initShifterBoxHandlers(self)
     local function toRightAllButtonClicked(buttonControl)
         -- move all entries
         self:MoveAllEntriesToRightList()
-        -- and disable the move-all button
-        buttonControl:SetState(BSTATE_DISABLED, true)
     end
 
     -- initialize the handler when the buttons are clicked


### PR DESCRIPTION
- resolves #14 
- remove fixed button-disable when moving all entries from one side to the other
- insteady rely on the `RefreshFilters()` call that happens within `MoveAllEntriesToLeftList()`