### PR TITLE
LibShifterBox 18 - Baertram -> PLEASE TEST too!

### DIFF
--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -561,8 +561,6 @@ function ShifterBoxList:New(shifterBox, control, isLeftList)
     obj.enabled = true
     obj.masterList = {}
     obj.shifterBox = shifterBox -- keep a reference to the "parent" ShifterBox
-    -- then trigger the callback if present
-    _fireCallback(shifterBox, control, { [true] = lib.EVENT_LEFT_LIST_CREATED, [false] = lib.EVENT_RIGHT_LIST_CREATED  }, isLeftList, shifterBox, isLeftList)
     return obj
 end
 
@@ -662,8 +660,8 @@ function ShifterBoxList:Initialize(control, shifterBoxSettings, isLeftList)
                         local hasSameShifterBoxParent = _hasSameShifterBoxParent(self, sourceListControl)
 
                         -- then trigger the callback if present
-                        _fireCallback(self.shifterBox, draggedOntoControl, { [true] = lib.EVENT_LEFT_LIST_ROW_ON_DRAG_END, [false] = lib.EVENT_RIGHT_LIST_ROW_ON_DRAG_END  }, self.shifterBox.isLeftList,
-                                self.shifterBox, self.shifterBox.isLeftList, draggedOntoControl, mouseButton, dragData, hasSameShifterBoxParent)
+                        _fireCallback(self.shifterBox, draggedOntoControl, { [true] = lib.EVENT_LEFT_LIST_ROW_ON_DRAG_END, [false] = lib.EVENT_RIGHT_LIST_ROW_ON_DRAG_END  }, isLeftList,
+                                self.shifterBox, isLeftList, draggedOntoControl, mouseButton, dragData, hasSameShifterBoxParent)
 
                         if hasSameShifterBoxParent then
                             local sourceList
@@ -692,6 +690,14 @@ function ShifterBoxList:Initialize(control, shifterBoxSettings, isLeftList)
         self.list:SetHandler("OnReceiveDrag", onReceiveDrag)
         self.list:SetMouseEnabled(true)
     end
+    --Any callbacks to register now from the settings (e.g. the "List created" one, which would not fire again later :-) )
+    if self.listBoxSettings.callbackRegister ~= nil then
+        for shifterBoxEvent, callbackFunc in pairs(self.listBoxSettings.callbackRegister) do
+            self.shifterBox:RegisterCallback(shifterBoxEvent, callbackFunc)
+        end
+    end
+    -- then trigger the callback if present
+    _fireCallback(self.shifterBox, control, { [true] = lib.EVENT_LEFT_LIST_CREATED, [false] = lib.EVENT_RIGHT_LIST_CREATED  }, isLeftList, self.shifterBox, isLeftList)
 end
 
 -- ZO_SortFilterList:RefreshData()      =>  BuildMasterList()   =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -142,7 +142,7 @@ local function _moveEntryFromTo(fromList, toList, key, shifterBox)
         retVar = true
         -- then trigger the callback if present
          _fireCallback(shifterBox, nil, lib.EVENT_ENTRY_MOVED,
-                key, value, categoryId, fromList.isLeftList, fromList, toList)
+                key, value, categoryId, toList.isLeftList, fromList, toList)
     end
     return retVar
 end

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -10,7 +10,7 @@ local function _errorText(textTemplate, ...)
     return errorTextStr
 end
 
-assert(not _G[LIB_IDENTIFIER], errorText(GetString(LIBSHIFTERBOX_ALLREADY_LOADED)))
+assert(not _G[LIB_IDENTIFIER], _errorText(GetString(LIBSHIFTERBOX_ALLREADY_LOADED)))
 
 local lib = {}
 _G[LIB_IDENTIFIER] = lib

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -553,7 +553,7 @@ local function _moveEntriesToOtherList(sourceList, keys, destList, shifterBox)
     -- refresh the display afterwards
     _refreshFilter(sourceList, true)
     _refreshFilter(destList)
-    return retVarLoop
+    return retVar
 end
 
 local function _moveEntryToOtherList(sourceList, key, destList, shifterBox)

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -141,8 +141,8 @@ local function _moveEntryFromTo(fromList, toList, key, shifterBox)
         toList:AddEntry(key, value, categoryId)
         retVar = true
         -- then trigger the callback if present
-        _fireCallback(shifterBox, nil, lib.EVENT_ENTRY_MOVED,
-                key, value, categoryId, fromList, toList)
+         _fireCallback(shifterBox, nil, lib.EVENT_ENTRY_MOVED,
+                key, value, categoryId, fromList.isLeftList, fromList, toList)
     end
     return retVar
 end

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -553,7 +553,7 @@ ShifterBoxList.SORT_KEYS = {
 
 function ShifterBoxList:New(shifterBox, control, isLeftList)
     local shifterBoxSettings = shifterBox.shifterBoxSettings
-    local obj = ZO_SortFilterList.New(self, control, shifterBoxSettings, isLeftList)
+    local obj = ZO_SortFilterList.New(self, control, shifterBoxSettings, isLeftList, shifterBox) -->ShifterBoxList:Initialize
     obj.buttonControl = control:GetNamedChild("Button")
     obj.buttonAllControl = control:GetNamedChild("AllButton")
     obj.buttonAllControl:SetState(BSTATE_DISABLED, true) -- init it as disabled
@@ -577,7 +577,7 @@ function ShifterBoxList:OnSelectionChanged(previouslySelectedData, selectedData,
     end
 end
 
-function ShifterBoxList:Initialize(control, shifterBoxSettings, isLeftList)
+function ShifterBoxList:Initialize(control, shifterBoxSettings, isLeftList, shifterBox)
     local selfVar = self
     self.shifterBoxSettings = shifterBoxSettings
     if isLeftList then
@@ -692,14 +692,12 @@ function ShifterBoxList:Initialize(control, shifterBoxSettings, isLeftList)
     end
     --Any callbacks to register now from the settings (e.g. the "List created" one, which would not fire again later :-) )
     if self.listBoxSettings.callbackRegister ~= nil then
-d("Registering events at initialization")
         for shifterBoxEventId, callbackFunc in pairs(self.listBoxSettings.callbackRegister) do
-d(">shifterBoxEventId: " ..tostring(shifterBoxEventId))
-            self.shifterBox:RegisterCallback(shifterBoxEventId, callbackFunc)
+            shifterBox:RegisterCallback(shifterBoxEventId, callbackFunc)
         end
     end
     -- then trigger the callback if present
-    _fireCallback(self.shifterBox, control, { [true] = lib.EVENT_LEFT_LIST_CREATED, [false] = lib.EVENT_RIGHT_LIST_CREATED  }, isLeftList, self.shifterBox, isLeftList)
+    _fireCallback(shifterBox, control, { [true] = lib.EVENT_LEFT_LIST_CREATED, [false] = lib.EVENT_RIGHT_LIST_CREATED  }, isLeftList, shifterBox, isLeftList)
 end
 
 -- ZO_SortFilterList:RefreshData()      =>  BuildMasterList()   =>  FilterScrollList()  =>  SortScrollList()    =>  CommitScrollList()
@@ -1219,7 +1217,6 @@ end
 -- ---------------------------------------------------------------------------------------------------------------------
 
 function ShifterBox:RegisterCallback(shifterBoxEvent, callbackFunction)
-d("[ShifterBox:RegisterCallback]shifterBoxEvent: " ..tostring(shifterBoxEvent))
     _assertValidShifterBoxEvent(shifterBoxEvent)
     assert(type(callbackFunction) == "function", _errorText("Invalid callbackFunction parameter of type '%s' provided! Must be of type 'function'.", type(callbackFunction)))
     -- register the callback with ESO

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -1,6 +1,6 @@
 local LIB_IDENTIFIER = "LibShifterBox"
 
-local function errorText(textTemplate, ...)
+local function _errorText(textTemplate, ...)
     local errorTextStr = LIB_IDENTIFIER .. "_Error: "
     if ... ~= nil then
         errorTextStr =  errorTextStr .. string.format(textTemplate, ...)
@@ -33,15 +33,15 @@ local FONT_WEIGHT = "soft-shadow-thin"
 
 --Shifter box events for the callbacks
 local shifterBoxEvents = {
-   [1] = "EVENT_ENTRY_HIGHLIGHTED",
-   [2] = "EVENT_ENTRY_UNHIGHLIGHTED",
-   [3] = "EVENT_ENTRY_MOVED",
-   [4] = "EVENT_LEFT_LIST_CLEARED",
-   [5] = "EVENT_RIGHT_LIST_CLEARED",
-   [6] = "EVENT_LEFT_LIST_ENTRY_ADDED",
-   [7] = "EVENT_RIGHT_LIST_ENTRY_ADDED",
-   [8] = "EVENT_LEFT_LIST_ENTRY_REMOVED",
-   [9] = "EVENT_RIGHT_LIST_ENTRY_REMOVED",
+   [1]  = "EVENT_ENTRY_HIGHLIGHTED",
+   [2]  = "EVENT_ENTRY_UNHIGHLIGHTED",
+   [3]  = "EVENT_ENTRY_MOVED",
+   [4]  = "EVENT_LEFT_LIST_CLEARED",
+   [5]  = "EVENT_RIGHT_LIST_CLEARED",
+   [6]  = "EVENT_LEFT_LIST_ENTRY_ADDED",
+   [7]  = "EVENT_RIGHT_LIST_ENTRY_ADDED",
+   [8]  = "EVENT_LEFT_LIST_ENTRY_REMOVED",
+   [9]  = "EVENT_RIGHT_LIST_ENTRY_REMOVED",
    [10] = "EVENT_LEFT_LIST_CREATED",
    [11] = "EVENT_RIGHT_LIST_CREATED",
    [12] = "EVENT_LEFT_LIST_ROW_ON_MOUSE_ENTER",
@@ -146,13 +146,13 @@ end
 
 local function _assertValidShifterBoxEvent(shifterBoxEvent)
     assert(allowedShifterBoxEvents[shifterBoxEvent] == true,
-            errorText("Invalid shifterBoxEvent parameter provided! Must be one of table \'LibShifterBox.allowedEventNames\'!")
+            _errorText("Invalid shifterBoxEvent parameter provided! Must be one of table \'LibShifterBox.allowedEventNames\'!")
     )
 end
 
 local function _assertKeyIsNotInTable(key, value, self, sideControl)
     local masterList = self.masterList
-    assert(masterList[key] == nil, errorText("Violation of UNIQUE KEY. Cannot insert duplicate key '%s' with value '%s' in control '%s'. The statement has been terminated.", tostring(key), tostring(value), sideControl:GetName()))
+    assert(masterList[key] == nil, _errorText("Violation of UNIQUE KEY. Cannot insert duplicate key '%s' with value '%s' in control '%s'. The statement has been terminated.", tostring(key), tostring(value), sideControl:GetName()))
 end
 
 local function _initShifterBoxControls(self)
@@ -261,35 +261,35 @@ local function _applyCustomSettings(customSettings)
     local function _assertPositiveNumber(customSettingsTbl, parameterName, settingsTbl)
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "number" and customValue > 0, errorText("Invalid %s parameter '%s' provided! Must be a numeric and positive.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "number" and customValue > 0, _errorText("Invalid %s parameter '%s' provided! Must be a numeric and positive.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
     local function _assertBoolean(customSettingsTbl, parameterName, settingsTbl)
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "boolean", errorText("Invalid %s parameter '%s' provided! Must be a boolean.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "boolean", _errorText("Invalid %s parameter '%s' provided! Must be a boolean.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
     local function _assertString(customSettingsTbl, parameterName, settingsTbl)
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "string", errorText("Invalid %s parameter '%s' provided! Must be a string.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "string", _errorText("Invalid %s parameter '%s' provided! Must be a string.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
     local function _assertStringValueKey(customSettingsTbl, parameterName, settingsTbl)
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "string" and (customValue == "value" or customValue == "key"), errorText("Invalid %s parameter '%s' provided! Must be either 'value' or 'key'.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "string" and (customValue == "value" or customValue == "key"), _errorText("Invalid %s parameter '%s' provided! Must be either 'value' or 'key'.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
     local function _assertFunction(customSettingsTbl, parameterName, settingsTbl)
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "function", errorText("Invalid %s parameter '%s' provided! Must be a function.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "function", _errorText("Invalid %s parameter '%s' provided! Must be a function.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
@@ -297,7 +297,7 @@ local function _applyCustomSettings(customSettings)
         local sounds = SOUNDS
         local customValue = customSettingsTbl[parameterName]
         if customValue ~= nil then
-            assert(type(customValue) == "string" and sounds[customValue] ~= nil, errorText("Invalid %s parameter '%s' provided! Must be a string and existing in the global SOUNDS table.", parameterName, tostring(customValue)))
+            assert(type(customValue) == "string" and sounds[customValue] ~= nil, _errorText("Invalid %s parameter '%s' provided! Must be a string and existing in the global SOUNDS table.", parameterName, tostring(customValue)))
             settingsTbl[parameterName] = customValue
         end
     end
@@ -1053,7 +1053,7 @@ function ShifterBox:New(uniqueAddonName, uniqueShifterBoxName, parentControl, cu
         existingShifterBoxes[uniqueAddonName] = {}
     end
     local addonShifterBoxes = existingShifterBoxes[uniqueAddonName]
-    assert(addonShifterBoxes[uniqueShifterBoxName] == nil, errorText("ShifterBox with the unique identifier '%s' is already registered for the addon '%s'!", tostring(uniqueShifterBoxName), tostring(uniqueAddonName)))
+    assert(addonShifterBoxes[uniqueShifterBoxName] == nil, _errorText("ShifterBox with the unique identifier '%s' is already registered for the addon '%s'!", tostring(uniqueShifterBoxName), tostring(uniqueAddonName)))
     local obj = ZO_Object.New(self)
     obj.addonName = uniqueAddonName
     obj.shifterBoxName = uniqueShifterBoxName
@@ -1101,7 +1101,7 @@ end
 -- @param width - the width for the whole shifterBox
 -- @param height - the height for the whole shifterBox (incl. headers if applicable)
 function ShifterBox:SetDimensions(width, height)
-    assert(type(width) == "number" and type(height) == "number", errorText("width and height must be numeric values!"))
+    assert(type(width) == "number" and type(height) == "number", _errorText("width and height must be numeric values!"))
     -- height must be at least 4x the height of the arrows
     if height < 4 * ARROW_SIZE then height = 4 * ARROW_SIZE end
     local singleListWidth, arrowOffset, arrowAllOffset = _getListBoxWidthAndArrowOffset(width, height)
@@ -1128,7 +1128,7 @@ function ShifterBox:SetHidden(hidden)
 end
 
 function ShifterBox:ShowCategory(categoryId)
-    assert(categoryId ~= nil, errorText("categoryId cannot be nil!"))
+    assert(categoryId ~= nil, _errorText("categoryId cannot be nil!"))
     ZO_ScrollList_ShowCategory(self.leftList.list, categoryId)
     ZO_ScrollList_ShowCategory(self.rightList.list, categoryId)
     _refreshFilters(self.leftList, self.rightList)
@@ -1167,7 +1167,7 @@ function ShifterBox:ShowAllCategories()
 end
 
 function ShifterBox:HideCategory(categoryId)
-    assert(categoryId ~= nil, errorText("categoryId cannot be nil!"))
+    assert(categoryId ~= nil, _errorText("categoryId cannot be nil!"))
     ZO_ScrollList_HideCategory(self.leftList.list, categoryId)
     ZO_ScrollList_HideCategory(self.rightList.list, categoryId)
     _refreshFilters(self.leftList, self.rightList, true)
@@ -1202,7 +1202,7 @@ end
 
 function ShifterBox:RegisterCallback(shifterBoxEvent, callbackFunction)
     _assertValidShifterBoxEvent(shifterBoxEvent)
-    assert(type(callbackFunction) == "function", errorText("Invalid callbackFunction parameter of type '%s' provided! Must be of type 'function'.", type(callbackFunction)))
+    assert(type(callbackFunction) == "function", _errorText("Invalid callbackFunction parameter of type '%s' provided! Must be of type 'function'.", type(callbackFunction)))
     -- register the callback with ESO
     local callbackIdentifier = _getUniqueShifterBoxEventName(self, shifterBoxEvent)
     CM:RegisterCallback(callbackIdentifier, callbackFunction)

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -120,7 +120,7 @@ local function _refreshFilter(list, checkForClearTrigger)
     list:RefreshFilters()
     if checkForClearTrigger and next(list.list.data) == nil then
         _fireCallback(list.shifterBox, nil, (list.isLeftList and lib.EVENT_LEFT_LIST_CLEARED) or lib.EVENT_RIGHT_LIST_CLEARED,
-                list.shifterBox, list.isLeftList)
+                list.isLeftList)
     end
 end
 
@@ -142,7 +142,7 @@ local function _moveEntryFromTo(fromList, toList, key, shifterBox)
         retVar = true
         -- then trigger the callback if present
         _fireCallback(shifterBox, nil, lib.EVENT_ENTRY_MOVED,
-                shifterBox, key, value, categoryId, fromList, toList)
+                key, value, categoryId, fromList, toList)
     end
     return retVar
 end
@@ -420,7 +420,7 @@ local function _removeEntriesFromList(list, keys)
     if hasAtLeastOneRemoved then
         -- then trigger the callback if present
         _fireCallback(list.shifterBox, nil, (list.isLeftList and lib.EVENT_LEFT_LIST_ENTRY_REMOVED) or lib.EVENT_RIGHT_LIST_ENTRY_REMOVED,
-                list.shifterBox, list.isLeftList, list, keys)
+                list.isLeftList, list, keys)
 
         _refreshFilter(list, true)
     end
@@ -520,7 +520,7 @@ local function _addEntriesToList(list, entries, replace, otherList, categoryId)
         if hasAtLeastOneAdded then
             -- then trigger the callback if present
             _fireCallback(list.shifterBox, nil, (list.isLeftList and lib.EVENT_LEFT_LIST_ENTRY_ADDED) or lib.EVENT_RIGHT_LIST_ENTRY_ADDED,
-                    list.shifterBox, list.isLeftList, list, keysAdded)
+                    list.isLeftList, list, keysAdded)
 
             -- Afterwards refresh the visualisation of the data
             _refreshFilter(list)
@@ -528,7 +528,7 @@ local function _addEntriesToList(list, entries, replace, otherList, categoryId)
             if hasAtLeastOneRemoved then
                 -- then trigger the callback if present
                 _fireCallback(list.shifterBox, nil, (list.isLeftList and lib.EVENT_LEFT_LIST_ENTRY_REMOVED) or lib.EVENT_RIGHT_LIST_ENTRY_REMOVED,
-                        list.shifterBox, list.isLeftList, list, keysRemoved)
+                        list.isLeftList, list, keysRemoved)
 
                 _refreshFilter(otherList, true)
             end

--- a/LibShifterBox/LibShifterBox.lua
+++ b/LibShifterBox/LibShifterBox.lua
@@ -1328,12 +1328,13 @@ end
 -- @param uniqueAddonName - a string identifer for the consuming addon
 -- @param uniqueShifterBoxName - a string identifier for the specific shifterBox
 -- @return an existing shifterBox CT_CONTROL object or nil if not found with the passed names
+--         2nd return param: The shifterbox instance of that control or nil
 function lib.GetControl(uniqueAddonName, uniqueShifterBoxName)
     local shifterBox = lib.GetShifterBox(uniqueAddonName, uniqueShifterBoxName)
     if shifterBox ~= nil then
-        return shifterBox.shifterBoxControl
+        return shifterBox.shifterBoxControl, shifterBox
     end
-    return nil
+    return nil, nil
 end
 
 function lib.Create(...)

--- a/LibShifterBox/LibShifterBox.txt
+++ b/LibShifterBox/LibShifterBox.txt
@@ -6,8 +6,8 @@
 
 ## Title: LibShifterBox
 ## Description: A library to aid in the creation of ShifterBoxes (aka Dual-ListBoxes)
-## Version: 0.4.2
-## AddOnVersion: 18
+## Version: {VERSION_NUMBER}
+## AddOnVersion: {BUILD_NUMBER}
 ## Author: Klingo
 ## APIVersion: 100035 101031
 ## IsLibrary: true

--- a/LibShifterBox/LibShifterBox.txt
+++ b/LibShifterBox/LibShifterBox.txt
@@ -6,10 +6,10 @@
 
 ## Title: LibShifterBox
 ## Description: A library to aid in the creation of ShifterBoxes (aka Dual-ListBoxes)
-## Version: {VERSION_NUMBER}
-## AddOnVersion: {BUILD_NUMBER}
+## Version: 0.4.2
+## AddOnVersion: 18
 ## Author: Klingo
-## APIVersion: 100033 100034
+## APIVersion: 100035 101031
 ## IsLibrary: true
 
 localization\en.lua

--- a/LibShifterBox/ShifterBox/ShifterBoxTemplate.xml
+++ b/LibShifterBox/ShifterBox/ShifterBoxTemplate.xml
@@ -1,7 +1,9 @@
 <GuiXml>
     <Controls>
+        <!-- The ZO_SortFilterList virtual template of the 2 list boxes (Shifter box) -->
         <Control name="ShifterBoxTemplate" resizeToFitDescendents="true" virtual="true">
             <Controls>
+                <!-- Left list -->
                 <Control name="$(parent)Left">
                     <Anchor point="TOPLEFT" />
                     <Controls>
@@ -45,6 +47,7 @@
                         </Button>
                     </Controls>
                 </Control>
+                <!-- Right list -->
                 <Control name="$(parent)Right">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)LeftHeaders" relativePoint="TOPRIGHT" offsetX="40" />
                     <Controls>
@@ -90,6 +93,7 @@
                 </Control>
             </Controls>
         </Control>
+        <!-- The row virtual template of the shifter box lists -->
         <Control  name="ShifterBoxEntryTemplate" verticalAlignment="CENTER" horizontalAlignment="LEFT" mouseEnabled="true" virtual="true">
             <Dimensions x="180" y="32" />
             <Controls>
@@ -99,5 +103,15 @@
                 </Label>
             </Controls>
         </Control>
+        <!-- The Top Level Control positioned at the cursor, to show dragged list entries -->
+        <TopLevelControl name="LibShifterBox_Cursor_TLC" mouseEnabled="false" hidden="true">
+			<Dimensions x="0" y="0" />
+			<Controls>
+                <Label name="$(parent)Label" font="ZoFontGame" color="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_SELECTED" horizontalAlignment="LEFT" verticalAlignment="TOP" text="">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT"/>
+                    <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT"/>
+                </Label>
+			</Controls>
+		</TopLevelControl>
     </Controls>
 </GuiXml>

--- a/LibShifterBox/localization/de.lua
+++ b/LibShifterBox/localization/de.lua
@@ -1,5 +1,6 @@
 local LSBStrings = {
-    LIBSHIFTERBOX_EMPTY = "leer"
+    LIBSHIFTERBOX_ALLREADY_LOADED   = "Ist bereits geladen",
+    LIBSHIFTERBOX_EMPTY             = "leer"
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/de.lua
+++ b/LibShifterBox/localization/de.lua
@@ -1,6 +1,7 @@
 local LSBStrings = {
     LIBSHIFTERBOX_ALLREADY_LOADED   = "Ist bereits geladen",
-    LIBSHIFTERBOX_EMPTY             = "leer"
+    LIBSHIFTERBOX_EMPTY             = "leer",
+    LIBSHIFTERBOX_DRAG_MULTIPLE     = " und <<1[keine weitere Zeile/1 weitere Zeile/$d weitere Zeilen]>>",
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/en.lua
+++ b/LibShifterBox/localization/en.lua
@@ -1,5 +1,6 @@
 local LSBStrings = {
-    LIBSHIFTERBOX_EMPTY = "empty"
+    LIBSHIFTERBOX_ALLREADY_LOADED   = "Is already loaded",
+    LIBSHIFTERBOX_EMPTY             = "empty"
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/en.lua
+++ b/LibShifterBox/localization/en.lua
@@ -1,6 +1,7 @@
 local LSBStrings = {
     LIBSHIFTERBOX_ALLREADY_LOADED   = "Is already loaded",
-    LIBSHIFTERBOX_EMPTY             = "empty"
+    LIBSHIFTERBOX_EMPTY             = "empty",
+    LIBSHIFTERBOX_DRAG_MULTIPLE     = " and <<1[no further rows/1 further row/$d further rows]>>",
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/fr.lua
+++ b/LibShifterBox/localization/fr.lua
@@ -1,5 +1,6 @@
 local LSBStrings = {
-    LIBSHIFTERBOX_EMPTY = "vide"
+    LIBSHIFTERBOX_ALLREADY_LOADED   = "Est déjà chargé",
+    LIBSHIFTERBOX_EMPTY             = "vide"
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/jp.lua
+++ b/LibShifterBox/localization/jp.lua
@@ -1,5 +1,6 @@
 local LSBStrings = {
-    LIBSHIFTERBOX_EMPTY = "空の"
+    LIBSHIFTERBOX_ALLREADY_LOADED   = "すでにロードされています",
+    LIBSHIFTERBOX_EMPTY             = "空の"
 }
 
 for key, value in pairs(LSBStrings) do

--- a/LibShifterBox/localization/ru.lua
+++ b/LibShifterBox/localization/ru.lua
@@ -1,5 +1,6 @@
 local LSBStrings = {
-    LIBSHIFTERBOX_EMPTY = "пустой"
+    LIBSHIFTERBOX_ALLREADY_LOADED   = "Уже загружено",
+    LIBSHIFTERBOX_EMPTY             = "пустой"
 }
 
 for key, value in pairs(LSBStrings) do

--- a/build/version.properties
+++ b/build/version.properties
@@ -2,5 +2,5 @@
 #Sat, 06 Mar 2021 15:13:15 +0100
 build.major=0
 build.minor=4
-build.patch=1
-build.revision=17
+build.patch=2
+build.revision=18


### PR DESCRIPTION
-Added function "errorText" for localized asserts and strip redundant…
… strings

-Changed asserts to use the function errorText
-Changed the possible/allowed events to be in a table and be dynamically added to the lib
-Added more callback events
-Added a new function "_fireCallback" to call the registered callbacks (to reduce the redundant code)
-Added new _assertFunction to the settings assert function
-Added new settings for the left and right list:
--Basically all parameters of the function ZO_ScrollList_AddDataType:
---rowOnMouseEnter: A function to call as the mouse enters the row of the list (e.g. show custom tooltip)
---rowOnMouseExit: A function to call as the mouse exits the row of the list (e.g. hide custom tooltip)
---rowOnMouseRightClick: A function to call as you right click on a row (e.g. show a context menu)
---rowSetupCallback: The setup callback function which should define the total row. Attention: It will call self:SetupRowEntry(rowControl, dataTabEnriched) automatically first! After that it will call your function here, and finally it will call  ZO_SortFilterList.SetupRow(self, rowControl, rowData)).
---rowDataTypeSelectSound: The sound (must be existing in global table SOUNDS) to play as a row with the datatype was selected
---rowResetControlCallback: A function to call as the control of the datatype was reset

--And in addition:
---rowSetupAdditionalDataCallback: A function to call AT THE START of the standard setupCallback function self:SetupRowEntry(rowControl, dataTabEnriched), which is able to change the entries of the data table (for the OnMouseEnter e.g. so that you got the data.tooltipText entry for the tooltip).

-Added new settings table entry "callbackRegister" where the key needs to be one of the available callbacks like lib.EVENT_LEFT_LIST_CREATED and the value a function for the callback. (This was needed to make the "list created" callback work as else the callback would only b registered AFTER the list were created already, and thus never fires. But it also maybe easier/better to find to add them all to the settings and let the for ..loop i the init function register them).

-Changed some funcitons to use less redundant Strings and code (like the assert settings functions)

Example settings could be e.g.:
local exampleLibShifterBoxCustomSettings = {
    leftList = {
        title = "Available sounds",
        callbackRegister = {
            [FCOChangeStuff.LSB.EVENT_LEFT_LIST_CREATED]            = function()
                d("LSB: Event left list created")
            end,
            [FCOChangeStuff.LSB.EVENT_RIGHT_LIST_CREATED]           = function()
                d("LSB: Event right list created")
            end,
            [FCOChangeStuff.LSB.EVENT_LEFT_LIST_ROW_ON_MOUSE_ENTER] = function()
                d("[FCOCS]LSB event left list row on mouse enter")
            end,
            [FCOChangeStuff.LSB.EVENT_LEFT_LIST_ROW_ON_MOUSE_EXIT]  = function()
                d("[FCOCS]LSB event left list row on mouse exit")
            end,
            [FCOChangeStuff.LSB.EVENT_LEFT_LIST_ROW_ON_DRAG_START]  = function()
                d("[FCOCS]LSB event left list row on drag start")
            end,
            [FCOChangeStuff.LSB.EVENT_RIGHT_LIST_ROW_ON_DRAG_END]   = function()
                d("[FCOCS]LSB event right list row on drag end")
            end,
        },
        rowOnMouseEnter = function(rowControl)
            local data = ZO_ScrollList_GetData(rowControl)
            d("LSB: OnMouseEnter: " ..tostring(data.tooltipText))
        end,
        rowOnMouseExit = function(rowControl) d("LSB: OnMouseExit")  end,
        rowOnMouseRightClick = function(rowControl, data) d("LSB: OnMouseRightClick") end,
        rowSetupCallback = function(rowControl, data)
            d("LSB: SetupCallback -> Calls self:SetupRowEntry, then this function, finally ZO_SortFilterList.SetupRow")
            data.tooltipText = "Hello world"
        end,
        rowDataTypeSelectSound = "ACTIVE_SKILL_RESPEC_MORPH_CHOSEN",
        rowResetControlCallback = function() d("LSB: ResetControlCallback")  end,
        rowSetupAdditionalDataCallback = function(rowControl, data)
            d("LSB: SetupAdditionalDataCallback")
                data.tooltipText = data.value
            return rowControl, data
        end,
    },
    rightList = {
        title = "Disabled sounds",
    }
}